### PR TITLE
fix: initialize ServiceLoaders from the FunctionFactory class loader …

### DIFF
--- a/core/src/main/java/io/questdb/ServerMain.java
+++ b/core/src/main/java/io/questdb/ServerMain.java
@@ -143,7 +143,10 @@ public class ServerMain {
         }
 
         final WorkerPool workerPool = new WorkerPool(configuration.getWorkerPoolConfiguration());
-        final FunctionFactoryCache functionFactoryCache = new FunctionFactoryCache(configuration.getCairoConfiguration(), ServiceLoader.load(FunctionFactory.class));
+        final FunctionFactoryCache functionFactoryCache = new FunctionFactoryCache(
+                configuration.getCairoConfiguration(),
+                ServiceLoader.load(FunctionFactory.class, FunctionFactory.class.getClassLoader())
+        );
         final ObjList<Closeable> instancesToClean = new ObjList<>();
 
         LogFactory.configureFromSystemProperties(workerPool);

--- a/core/src/main/java/io/questdb/griffin/SqlCompiler.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompiler.java
@@ -122,7 +122,10 @@ public class SqlCompiler implements Closeable {
         this.lexer = new GenericLexer(configuration.getSqlLexerPoolCapacity());
         this.functionParser = new FunctionParser(
                 configuration,
-                functionFactoryCache != null ? functionFactoryCache : new FunctionFactoryCache(engine.getConfiguration(), ServiceLoader.load(FunctionFactory.class))
+                functionFactoryCache != null
+                                     ? functionFactoryCache
+                                     : new FunctionFactoryCache(engine.getConfiguration(), ServiceLoader.load(
+                                             FunctionFactory.class, FunctionFactory.class.getClassLoader()))
         );
         this.codeGenerator = new SqlCodeGenerator(engine, configuration, functionParser);
 

--- a/core/src/test/java/io/questdb/griffin/WhereClauseParserTest.java
+++ b/core/src/test/java/io/questdb/griffin/WhereClauseParserTest.java
@@ -50,7 +50,10 @@ public class WhereClauseParserTest extends AbstractCairoTest {
     private final PostOrderTreeTraversalAlgo traversalAlgo = new PostOrderTreeTraversalAlgo();
     private final PostOrderTreeTraversalAlgo.Visitor rpnBuilderVisitor = rpn::onNode;
     private final QueryModel queryModel = QueryModel.FACTORY.newInstance();
-    private final FunctionParser functionParser = new FunctionParser(configuration, new FunctionFactoryCache(configuration, ServiceLoader.load(FunctionFactory.class)));
+    private final FunctionParser functionParser = new FunctionParser(
+            configuration,
+            new FunctionFactoryCache(configuration, ServiceLoader.load(FunctionFactory.class, FunctionFactory.class.getClassLoader()))
+    );
     protected BindVariableService bindVariableService = new BindVariableServiceImpl(configuration);
     private SqlCompiler compiler;
     private SqlExecutionContext sqlExecutionContext;


### PR DESCRIPTION
…(#1172)

In environments where the QuestDb classes are not loaded by the system
class loader and no context class loader is explicitly set, functions
will not be found when initializing a ServiceLoader without passing
a class loader explicitly.

This change will always work assuming that SQL functions are loadable
from the same class loader as FunctionFactory, that is, there is no support
for plugging in external functions by passing a class loader capable of loading
those classes. I think that assumption is true for QuestDb as I can't find
any mention of class loaders in the QuestDb doc, and it would be challenging to
make this work because the external class loader would also need to correctly
load the functions bundled with QuestDb.